### PR TITLE
メール検索に使うクエリを変更

### DIFF
--- a/src/autoClickPointIncome.ts
+++ b/src/autoClickPointIncome.ts
@@ -24,7 +24,7 @@ export function autoClickPointIncome (): void {
 }
 
 export function getGmailThreads_ (): GmailThread[] {
-  return GmailApp.search('ポイントインカム クリック from:mag@pointi.jp');
+  return GmailApp.search('click_mail_magazine.php from:mag@pointi.jp ');
 }
 
 export function pickUrlsFromMessageBody_ (messageBody: string): string[] {


### PR DESCRIPTION
メール検索に使うクエリを変更

`click_mail_magazine.php` で検索を掛けて, タイトルにクリックが入っていないメールも抽出する